### PR TITLE
fix(demo): propagate data_format to build_dataset in example8

### DIFF
--- a/demo/example8_DCN_with_emb_feature_as_input.py
+++ b/demo/example8_DCN_with_emb_feature_as_input.py
@@ -47,10 +47,11 @@ if __name__ == '__main__':
 
     # Build dataset and remap data paths to parquet files
     params["train_data"], params["valid_data"], params["test_data"] = \
-        build_dataset(feature_encoder, 
+        build_dataset(feature_encoder,
                       train_data=params["train_data"],
                       valid_data=params["valid_data"],
-                      test_data=params["test_data"])
+                      test_data=params["test_data"],
+                      data_format=params["data_format"])
     
     # Get feature_map that defines feature specs
     data_dir = os.path.join(params['data_root'], params['dataset_id'])


### PR DESCRIPTION
## Summary

Fixes #168.

`demo/example8_DCN_with_emb_feature_as_input.py` uses parquet input (its `dataset_config.yaml` sets `data_format: parquet`), but the `build_dataset(...)` call omits `data_format`. `FeatureProcessor.read_data` then defaults to `data_format="csv"` and appends `"*.csv"` to the parquet directory, producing:

```
Reading files: ../data/tiny_emb/train.parquet/*.csv
AssertionError: Invalid data path: ../data/tiny_emb/train.parquet/*.csv
```

Passing `data_format=params["data_format"]` through `**kwargs` to `read_data` selects the parquet branch (`pl.scan_parquet`) correctly.

## Change

One-line: add `data_format=params["data_format"]` to the `build_dataset(...)` call in example8.

## Test plan
- [x] Repro matches issue #168 before the fix
- [x] After the fix, `build_dataset` is invoked with `data_format="parquet"` and `read_data` takes the parquet path
- [x] example1/4/5/7 behaviour unchanged (they use `data_format: csv`, i.e. the default of `read_data`)